### PR TITLE
Add error log to webgl templates

### DIFF
--- a/Scuti/Editor/CheckWebGLTemplateOnBuild.cs
+++ b/Scuti/Editor/CheckWebGLTemplateOnBuild.cs
@@ -1,0 +1,29 @@
+using UnityEditor;
+using UnityEngine;
+
+public class CheckWebGLTemplateOnBuild
+{
+    [InitializeOnLoadMethod]
+    private static void RegisterBuildHandler()
+    {
+        BuildPlayerWindow.RegisterBuildPlayerHandler(CheckWebGLTemplatesBeforeBuild);
+    }
+
+    private static void CheckWebGLTemplatesBeforeBuild(BuildPlayerOptions buildPlayerOptions)
+    {
+        if (buildPlayerOptions.target == BuildTarget.WebGL)
+        {
+            string templateFolderPath = Application.dataPath + "/WebGLTemplates";
+            bool folderExists = System.IO.Directory.Exists(templateFolderPath);
+
+            if (!folderExists)
+            {
+                Debug.LogError("WebGLTemplates folder does not exist. Create the folder using the Scuti menu before building for WebGL.");
+                return;
+            }
+        }
+
+        // Continue with the build process
+        BuildPlayerWindow.DefaultBuildMethods.BuildPlayer(buildPlayerOptions);
+    }
+}

--- a/Scuti/Editor/CheckWebGLTemplateOnBuild.cs
+++ b/Scuti/Editor/CheckWebGLTemplateOnBuild.cs
@@ -18,7 +18,7 @@ public class CheckWebGLTemplateOnBuild
 
             if (!folderExists)
             {
-                Debug.LogError("WebGLTemplates folder does not exist. Create the folder using the Scuti menu before building for WebGL.");
+                ScutiLogger.LogError("WebGLTemplates folder does not exist. Create the folder using the Scuti menu before building for WebGL.");
                 return;
             }
         }

--- a/Scuti/Editor/CheckWebGLTemplateOnBuild.cs.meta
+++ b/Scuti/Editor/CheckWebGLTemplateOnBuild.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3fa10d42da9e0984a9505b4108ef279e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scuti/Editor/ScutiEditorWindow.cs
+++ b/Scuti/Editor/ScutiEditorWindow.cs
@@ -307,8 +307,22 @@ public class ScutiEditorWindow : EditorWindow
     [MenuItem("Scuti/Copy WebGL Template")]
     static void CopyWebGLTemplates()
     {
-        FileUtil.CopyFileOrDirectory(ScutiConstants.PACKAGEFOLDERPATH, ScutiConstants.DESTINATIONFOLDERPATH);
-        AssetDatabase.Refresh();
-        Debug.Log("Package folder copied successfully!");
+        try
+        {
+            FileUtil.CopyFileOrDirectory(ScutiConstants.PACKAGEFOLDERPATH, ScutiConstants.DESTINATIONFOLDERPATH);
+            AssetDatabase.Refresh();
+            Debug.Log("Package folder copied successfully!");
+        }
+        catch (System.Exception e)
+        {
+            if(e.GetType() == typeof (IOException))
+            {
+                Debug.LogError("Files were not copied, make sure that there is no other folder called WebGLTemplates in the \"Assets\" folder");
+            }
+            else
+            {
+                Debug.Log(e);
+            }
+        }
     }
 }

--- a/Scuti/Editor/ScutiEditorWindow.cs
+++ b/Scuti/Editor/ScutiEditorWindow.cs
@@ -311,17 +311,17 @@ public class ScutiEditorWindow : EditorWindow
         {
             FileUtil.CopyFileOrDirectory(ScutiConstants.PACKAGEFOLDERPATH, ScutiConstants.DESTINATIONFOLDERPATH);
             AssetDatabase.Refresh();
-            Debug.Log("Package folder copied successfully!");
+            ScutiLogger.Log("Package folder copied successfully!");
         }
         catch (System.Exception e)
         {
             if(e.GetType() == typeof (IOException))
             {
-                Debug.LogError("Files were not copied, make sure that there is no other folder called WebGLTemplates in the \"Assets\" folder");
+                ScutiLogger.LogError("Files were not copied, make sure that there is no other folder called WebGLTemplates in the \"Assets\" folder");
             }
             else
             {
-                Debug.Log(e);
+                ScutiLogger.LogError(e);
             }
         }
     }


### PR DESCRIPTION
When user create the webGL templates now it shows an error message when the template is already created.